### PR TITLE
[Security] Update deprecated Aqua scanner options

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run Aqua scanner
         uses: docker://aquasec/aqua-scanner
         with:
-          args: trivy fs --sast --reachability --scanners config,vuln,secret .
+          args: trivy fs --sast --reachability --scanners misconfig,vuln,secret .
           # To customize which severities add the following flag: --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
           # To enable SAST scanning, add: --sast
           # To enable reachability scanning, add: --reachability


### PR DESCRIPTION
Misconguration engine activation option move from `config` to `misconfig`.